### PR TITLE
Drop support for Python < 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,5 @@
 dist: bionic
 language: python
-# blocklist
-branches:
-  except:
-  - dev
-# safelist
-branches:
-  only:
-  - master
 sudo: required
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: python
 # blocklist
 branches:
@@ -16,7 +17,10 @@ before_install:
   - echo "import time; time.sleep(20)" | python
   - cp tests/localsettings.py.template tests/localsettings.py
 python:
-  - "3.5"
+  - "3.7"
+  - "3.8"
+  - "3.9"
+  - "3.10"
 # command to install dependencies
 install: "pip3 install -e ."
 # command to run tests

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Python client for Fedora Commons 4.
 
 ## Requirements
 
-  * Python 3.5+
+  * Python 3.7 - 3.10
   * [Fedora Commons 4.7+]((http://fedorarepository.org/))
 
 ## Installation

--- a/pyfc4/models.py
+++ b/pyfc4/models.py
@@ -7,7 +7,6 @@ import json
 import pdb
 import rdflib
 from rdflib.compare import to_isomorphic, graph_diff
-import rdflib_jsonld
 import requests
 import time
 from types import SimpleNamespace
@@ -608,7 +607,7 @@ class API(object):
 
 		# parse graph
 		graph = rdflib.Graph().parse(
-			data=data.decode('utf-8'),
+			data=data,
 			format=parse_format)
 
 		# return graph
@@ -705,11 +704,11 @@ class SparqlUpdate(object):
 			sparql_query += "PREFIX %s: <%s>\n" % (ns_prefix, str(ns_uri))
 
 		# deletes
-		removed_serialized = self.diffs.removed.serialize(format='nt').decode('utf-8')
+		removed_serialized = self.diffs.removed.serialize(format='nt')
 		sparql_query += '\nDELETE {\n%s}\n\n' % removed_serialized
 
 		# inserts
-		added_serialized = self.diffs.added.serialize(format='nt').decode('utf-8')
+		added_serialized = self.diffs.added.serialize(format='nt')
 		sparql_query += '\nINSERT {\n%s}\n\n' % added_serialized
 
 		# where (not yet implemented)
@@ -861,7 +860,7 @@ class Resource(object):
 					serialization_format = self.repo.default_serialization
 				data = self.rdf.graph.serialize(format=serialization_format)
 				logger.debug('Serialized graph used for resource creation:')
-				logger.debug(data.decode('utf-8'))
+				logger.debug(data)
 				self.headers['Content-Type'] = serialization_format
 
 			# fire creation request
@@ -1579,7 +1578,7 @@ class Resource(object):
 			format (str): expecting serialization formats accepted by rdflib.serialization(format=)
 		'''
 
-		return self.rdf.graph.serialize(format=format).decode('utf-8')
+		return self.rdf.graph.serialize(format=format)
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pytest
 pytest-cov
-rdflib
-rdflib-jsonld
-requests
+rdflib < 7.0 >= 6.1.1
+requests < 3.0 > 2.27.0

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pyfc4',
-      version='0.6',
+      version='0.7',
       description='Python 3 client for Fedora Commons 4',
       url='http://github.com/ghukill/pyfc4',
       author='Graham Hukill',
@@ -11,8 +11,14 @@ setup(name='pyfc4',
         'pytest',
         'pytest-cov',
         'rdflib',
-        'rdflib-jsonld',
         'requests'
+      ],
+      classifiers = [
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
       ],
       packages=['pyfc4', 'pyfc4.plugins', 'pyfc4.plugins.pcdm'],
       zip_safe=False)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -86,11 +86,10 @@ class TestBasicCRUDPUT(object):
 	# test bad uri
 	def test_bad_uri(self):
 
-		with pytest.raises(Exception) as excinfo:
-			repo.get_resource('*%($')
-		assert 'error retrieving resource' in str(excinfo.value)	
+		result = repo.get_resource('*%($')
+		assert result == False
 
-	
+
 	# create foo (basic container)
 	def test_create_bc(self):
 
@@ -254,7 +253,7 @@ class TestBinaryUpload(object):
 
 	# upload file-like object
 	def test_file_like_object(self):
-		
+
 		baz1 = Binary(repo, '%s/foo/baz1' % testing_container_uri)
 		baz1.binary.data = open('README.md','rb')
 		baz1.binary.mimetype = 'text/plain'
@@ -352,7 +351,7 @@ class TestBasicRelationship(object):
 		foo.update()
 
 		# confirm triples were added
-		for val in ['windy night','stormy seas']:			
+		for val in ['windy night','stormy seas']:
 			# assert (foo.uri, foo.rdf.prefixes.dc.subject, rdflib.term.Literal(val)) in foo.rdf.graph
 			assert (foo.uri, foo.rdf.prefixes.dc.subject, rdflib.term.Literal(val, datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#string'))) in foo.rdf.graph
 
@@ -365,7 +364,7 @@ class TestBasicRelationship(object):
 		'''
 
 		# get foo
-		foo = repo.get_resource('%s/foo' % testing_container_uri)		
+		foo = repo.get_resource('%s/foo' % testing_container_uri)
 
 		# set (modify) title
 		foo.set_triple(foo.rdf.prefixes.dc.title, 'one hit wonder')
@@ -674,7 +673,7 @@ class TestVersions(object):
 
 		# create versions and confirm exists
 		v1 = baz.create_version('v1')
-		assert type(baz.versions.v1) == ResourceVersion	
+		assert type(baz.versions.v1) == ResourceVersion
 
 
 # fixity
@@ -770,4 +769,3 @@ class TestTeardown(object):
 		tc.delete()
 		tc = repo.get_resource(testing_container_uri)
 		assert tc == False
-


### PR DESCRIPTION
This drops support for Python versions lower than 3.6.
- Targets version ranges in requirements.txt
- Updates string handling
- Updates tests

@ghukill looking for a second set of eyes on this. Also trying to get Travis CI to run on this repo - you may need to update some settings?